### PR TITLE
Add GitProvider module with basic functionality

### DIFF
--- a/client/Pipfile
+++ b/client/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 click = "*"
+gitpython = "*"
 
 [requires]
 python_version = "3.7"

--- a/client/Pipfile.lock
+++ b/client/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e6728243c3982bd95c23ad63dc24514046979d9cf07efbb6dc60150bdf182788"
+            "sha256": "3c654421bc0a8fe0a93259af62bb8e1e34f267d5f59678e6fd714f791e8f2287"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,28 @@
             ],
             "index": "pypi",
             "version": "==7.0"
+        },
+        "gitdb2": {
+            "hashes": [
+                "sha256:83361131a1836661a155172932a13c08bda2db3674e4caa32368aa6eb02f38c2",
+                "sha256:e3a0141c5f2a3f635c7209d56c496ebe1ad35da82fe4d3ec4aaa36278d70648a"
+            ],
+            "version": "==2.0.5"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:563221e5a44369c6b79172f455584c9ebbb122a13368cc82cb4b5addff788f82",
+                "sha256:8237dc5bfd6f1366abeee5624111b9d6879393d84745a507de0fda86043b65a8"
+            ],
+            "index": "pypi",
+            "version": "==2.1.11"
+        },
+        "smmap2": {
+            "hashes": [
+                "sha256:0555a7bf4df71d1ef4218e4807bbf9b201f910174e6e08af2e138d4e517b4dde",
+                "sha256:29a9ffa0497e7f2be94ca0ed1ca1aa3cd4cf25a1f6b4f5f87f74b46ed91d609a"
+            ],
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/client/utils/git.py
+++ b/client/utils/git.py
@@ -1,0 +1,68 @@
+import git
+
+
+class GitProvider:
+    """Provides an interface for interacting with git repositories.
+    
+    :param path: path to the repository. If not given, GitPython will
+    traverse the parent directories in search for a match.
+    """
+
+    def __init__(self, path: str = None):
+        self._specified_path = path
+        self._repo = None
+
+    @property
+    def repository(self) -> object:
+        """Returns the GitPython object of a selected repository."""
+
+        if not self._repo:
+            if self._specified_path:
+                repo = git.Repo(self._specified_path)
+            else:
+                repo = git.Repo(search_parent_directories=True)
+
+            # assert not repo.bare
+            self._repo = repo
+        return self._repo
+
+    @property
+    def active_branch(self) -> str:
+        """Returns the name of the active branch."""
+
+        return self.repository.active_branch.name
+
+    @property
+    def latest_commit(self) -> str:
+        """Returns the hash of a latest commit in the active branch."""
+
+        return self.repository.head.object.hexsha
+
+    @property
+    def is_dirty(self) -> bool:
+        """Checks whether there are uncommited changes in the repository."""
+
+        return self.repository.is_dirty()
+
+    def remotes(self, include_name=True, include_url=True) -> list:
+        """Retrieves a list of remotes defined in the repository.
+        
+        :param include_name: whether to include the names of remotes
+        :param include_url: whether to include the urls of remotes
+        :returns: a list of remotes in a requested schema"""
+
+        if not include_name and not include_url:
+            raise Exception
+
+        output = []
+        remotes = self.repository.remotes
+        for remote in remotes:
+            entry = []
+            if include_name:
+                entry.append(remote.name)
+            if include_url:
+                entry.append(remote.url)
+
+            output.append(entry)
+
+        return output


### PR DESCRIPTION
The introduced module allows one to fetch data about version control,
such as: fetching information about the repository, active branch,
defined remotes, or just the hash/name of the latest commit.

Resolves #3 